### PR TITLE
Logge til elastic

### DIFF
--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -21,6 +21,11 @@ spec:
       value: "2022-11-28"
     - name: GITHUB_API_URL
       value: "https://api.github.com/"
+  observability:
+    logging:
+      destinations:
+        - id: loki
+        - id: elastic
   accessPolicy:
     outbound:
       rules:


### PR DESCRIPTION
### Behov / Bakgrunn
Nais jobben logger bare til loki/grafana, mens elastic/open search er teamets foretrukne loggeverktøy 

### Løsning
Aktiverer logging også til Open Search
